### PR TITLE
Improve viewport navigation: added camera position HUD, speed scaling…

### DIFF
--- a/Engine/Include/Layers/EditorLayer.hpp
+++ b/Engine/Include/Layers/EditorLayer.hpp
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include "Layers/Layer.hpp"
 #include "Core/Events/KeyEvent.h"
@@ -14,9 +14,10 @@ namespace TE {
     {
         bool ShowPhysicsColliders = false;
         bool AllowNavigation = true;
-        float CameraSpeed = 10.0f;
+        float SpeedMultiplier = 1.0f; // Slider 0.1 to 100
+        float BaseCameraSpeed = 100.0f;
         float ZoomSpeed = 2.0f;
-        // Theme settings can go here or remain in the dedicated function
+        float DefaultZoom = 10.0f;
     };
 
     struct ProjectSettings

--- a/Engine/Include/Layers/EditorLayer.hpp
+++ b/Engine/Include/Layers/EditorLayer.hpp
@@ -1,103 +1,111 @@
 #pragma once
 
-#include "Layers/Layer.hpp"
+#include "Core/Events/ApplicationEvent.h"
 #include "Core/Events/KeyEvent.h"
 #include "Core/Events/MouseEvent.h"
-#include "Core/Events/ApplicationEvent.h"
-#include "Core/Events/ApplicationEvent.h"
-#include <string>
+#include "Layers/Layer.hpp"
 #include "Renderer/Framebuffer.hpp"
+#include <string>
 
-namespace TE {
+namespace TE
+{
 
-    struct EditorSettings
+struct EditorSettings
+{
+    bool ShowPhysicsColliders = false;
+    bool AllowNavigation = true;
+    float SpeedMultiplier = 1.0f; // Slider 0.1 to 100
+    float BaseCameraSpeed = 100.0f;
+    float ZoomSpeed = 2.0f;
+    float DefaultZoom = 10.0f;
+};
+
+struct ProjectSettings
+{
+    enum class GameType
     {
-        bool ShowPhysicsColliders = false;
-        bool AllowNavigation = true;
-        float SpeedMultiplier = 1.0f; // Slider 0.1 to 100
-        float BaseCameraSpeed = 100.0f;
-        float ZoomSpeed = 2.0f;
-        float DefaultZoom = 10.0f;
+        TwoD,
+        ThreeD
+    };
+    enum class TwoDMode
+    {
+        TopDown,
+        SideScroller
     };
 
-    struct ProjectSettings
-    {
-        enum class GameType { TwoD, ThreeD };
-        enum class TwoDMode { TopDown, SideScroller };
+    GameType ConfigType = GameType::TwoD;
+    TwoDMode Mode2D = TwoDMode::TopDown;
+};
 
-        GameType ConfigType = GameType::TwoD;
-        TwoDMode Mode2D = TwoDMode::TopDown; 
-    };
+class TE_API EditorLayer : public Layer
+{
+public:
+    EditorLayer(const std::string &name = "EditorLayer");
+    virtual ~EditorLayer();
 
-    class TE_API EditorLayer : public Layer
-    {
-    public:
-        EditorLayer(const std::string& name = "EditorLayer");
-        virtual ~EditorLayer();
+    virtual void OnAttach() override;
+    virtual void OnDetach() override;
+    virtual void OnUpdate() override;
+    virtual void OnImGuiRender() override;
+    virtual void OnEvent(Event &event) override;
 
-        virtual void OnAttach() override;
-        virtual void OnDetach() override;
-        virtual void OnUpdate() override;
-        virtual void OnImGuiRender() override;
-        virtual void OnEvent(Event& event) override;
+private:
+    bool OnKeyPressed(KeyPressedEvent &e);
+    bool OnMouseButtonPressed(MouseButtonPressedEvent &e);
+    bool OnMouseScrolled(MouseScrolledEvent &e);
 
-    private:
-        bool OnKeyPressed(KeyPressedEvent& e);
-        bool OnMouseButtonPressed(MouseButtonPressedEvent& e);
-        bool OnMouseScrolled(MouseScrolledEvent& e);
-        
-        // UI Helpers
-        void SetDarkThemeColors();
-        void UI_DrawMenubar();
-        void UI_DrawToolbar();
+    // UI Helpers
+    void SetDarkThemeColors();
+    void UI_DrawMenubar();
+    void UI_DrawToolbar();
 
-        // Panels
-        void UI_DrawSceneHierarchy();
-        void UI_DrawProperties();
-        void UI_DrawContentBrowser();
-        void UI_DrawViewport();
-        void UI_DrawSettingsPanel(); // New
-        void UI_DrawProjectSettingsPanel(); // New
+    // Panels
+    void UI_DrawSceneHierarchy();
+    void UI_DrawProperties();
+    void UI_DrawContentBrowser();
+    void UI_DrawViewport();
+    void UI_DrawSettingsPanel();        // New
+    void UI_DrawProjectSettingsPanel(); // New
 
-        // Navigation
-        void UpdateCamera(float dt);
+    // Navigation
+    void UpdateCamera(float dt);
 
-    private:
-        // Layout State
-        bool m_ShowSceneHierarchy = true;
-        bool m_ShowProperties = true;
-        bool m_ShowContentBrowser = true;
-        bool m_ShowViewport = true;
-        bool m_ShowSettings = false;
-        bool m_ShowProjectSettings = false;
+private:
+    // Layout State
+    bool m_ShowSceneHierarchy = true;
+    bool m_ShowProperties = true;
+    bool m_ShowContentBrowser = true;
+    bool m_ShowViewport = true;
+    bool m_ShowSettings = false;
+    bool m_ShowProjectSettings = false;
 
-        bool m_ViewportFocused = false;
-        bool m_ViewportHovered = false;
-        
-        // State
-        EditorSettings m_EditorSettings;
-        ProjectSettings m_ProjectSettings;
-        
-        // Camera State
-        glm::vec3 m_CameraPosition = { 0.0f, 0.0f, 10.0f };
-        float m_CameraZoom = 10.0f; // Ortho size or Z distance
-        
-        // Mock State for now (Should be moved to proper Panel classes)
-        std::string m_SelectedEntity = "";
-        
-        // Resources
-        std::shared_ptr<class Texture> m_FileIcon;
-        std::shared_ptr<class Texture> m_FolderIcon; // Need this
-        std::shared_ptr<class Framebuffer> m_Framebuffer;
-        std::shared_ptr<class Renderer2D> m_Renderer2D;
-        
-        // Physics
-        std::shared_ptr<class PhysicsWorld> m_PhysicsWorld;
-        std::vector<struct RigidBody*> m_TestBodies;
-        std::shared_ptr<class Material> m_DebugMaterial;
+    bool m_ViewportFocused = false;
+    bool m_ViewportHovered = false;
 
-        bool m_ViewportSizeChanged = false; // Tracks if we need resize
-        float m_LastViewportX = 0, m_LastViewportY = 0;
-    };
+    // State
+    EditorSettings m_EditorSettings;
+    ProjectSettings m_ProjectSettings;
 
-}
+    // Camera State
+    glm::vec3 m_CameraPosition = {0.0f, 0.0f, 10.0f};
+    float m_CameraZoom = 10.0f; // Ortho size or Z distance
+
+    // Mock State for now (Should be moved to proper Panel classes)
+    std::string m_SelectedEntity = "";
+
+    // Resources
+    std::shared_ptr<class Texture> m_FileIcon;
+    std::shared_ptr<class Texture> m_FolderIcon; // Need this
+    std::shared_ptr<class Framebuffer> m_Framebuffer;
+    std::shared_ptr<class Renderer2D> m_Renderer2D;
+
+    // Physics
+    std::shared_ptr<class PhysicsWorld> m_PhysicsWorld;
+    std::vector<struct RigidBody *> m_TestBodies;
+    std::shared_ptr<class Material> m_DebugMaterial;
+
+    bool m_ViewportSizeChanged = false; // Tracks if we need resize
+    float m_LastViewportX = 0, m_LastViewportY = 0;
+};
+
+} // namespace TE

--- a/Engine/src/Core/Layers/EditorLayer.cpp
+++ b/Engine/src/Core/Layers/EditorLayer.cpp
@@ -1,8 +1,10 @@
 #include "Layers/EditorLayer.hpp"
 #include "Core/Application.h"
+#include "Core/KeyCodes.hpp"
 #include "Core/Log.h"
 #include "Core/Physics/PhysicsWorld.hpp"
 #include "Core/Project/Project.hpp"
+#include "Input/Input.hpp"
 #include "Renderer/Framebuffer.hpp"
 #include "Renderer/Material.hpp"
 #include "Renderer/RenderCommand.hpp"
@@ -389,9 +391,9 @@ void EditorLayer::UI_DrawSceneHierarchy()
             ImGui::Separator();
         };
 
-        DrawEntityNode("Main Camera");
-        DrawEntityNode("Directional Light");
-        DrawEntityNode("Player Start");
+        DrawEntityNode("Main Camera (Mock)");
+        DrawEntityNode("Directional Light (Mock)");
+        DrawEntityNode("Player Start (Mock)");
 
         ImGui::PopStyleColor();
         ImGui::PopStyleVar(2);
@@ -588,24 +590,50 @@ void EditorLayer::UI_DrawViewport()
                      ImVec2{1, 0});
     }
 
-    auto drawList = ImGui::GetWindowDrawList();
-    if (m_ShowViewport)
-    {
-        ImVec2 winPos = ImGui::GetWindowPos();
-        ImVec2 winSize = ImGui::GetWindowSize();
-        float GRID_STEP = 64.0f;
+        auto drawList = ImGui::GetWindowDrawList();
+        if (m_ShowViewport)
+        {
+            ImVec2 winPos = ImGui::GetWindowPos();
+            ImVec2 winSize = ImGui::GetWindowSize();
+            
+            // Base grid step at default zoom
+            float BASE_GRID_STEP = 64.0f;
+            // Scale grid step based on camera zoom relative to default
+            float visualGridStep = BASE_GRID_STEP * (m_EditorSettings.DefaultZoom / m_CameraZoom);
+            
+            // Subdivide or clump if grid gets too small/large
+            if (visualGridStep < 10.0f) visualGridStep *= 10.0f;
+            if (visualGridStep > 500.0f) visualGridStep /= 10.0f;
 
-        ImU32 gridColor = IM_COL32(200, 200, 200, 40);
+            ImU32 gridColor = IM_COL32(200, 200, 200, 40);
 
-        for (float x = fmodf(0.0f, GRID_STEP); x < winSize.x; x += GRID_STEP)
-            drawList->AddLine(ImVec2(winPos.x + x, winPos.y), ImVec2(winPos.x + x, winPos.y + winSize.y), gridColor);
+            // Calculate scrolling offset based on camera position and zoom
+            float offsetX = fmodf(-m_CameraPosition.x * (m_EditorSettings.DefaultZoom / m_CameraZoom), visualGridStep);
+            float offsetY = fmodf(m_CameraPosition.y * (m_EditorSettings.DefaultZoom / m_CameraZoom), visualGridStep);
 
-        for (float y = fmodf(0.0f, GRID_STEP); y < winSize.y; y += GRID_STEP)
-            drawList->AddLine(ImVec2(winPos.x, winPos.y + y), ImVec2(winPos.x + winSize.x, winPos.y + y), gridColor);
-    }
+            for (float x = offsetX; x < winSize.x; x += visualGridStep)
+                drawList->AddLine(ImVec2(winPos.x + x, winPos.y), ImVec2(winPos.x + x, winPos.y + winSize.y), gridColor);
+            
+            for (float y = offsetY; y < winSize.y; y += visualGridStep)
+                drawList->AddLine(ImVec2(winPos.x, winPos.y + y), ImVec2(winPos.x + winSize.x, winPos.y + y), gridColor);
+        }
 
-    ImGui::SetCursorPos(ImVec2(10, 30));
-    ImGui::Text("Viewport Size: %.0f, %.0f", m_LastViewportX, m_LastViewportY);
+        ImGui::SetCursorPos(ImVec2(10, 30));
+        ImGui::TextColored(ImVec4(0.0f, 1.0f, 1.0f, 1.0f), "Viewport Size: %.0f, %.0f", m_LastViewportX, m_LastViewportY);
+        ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.0f, 1.0f), "Camera Pos: %.2f, %.2f | Zoom: %.2f", m_CameraPosition.x, m_CameraPosition.y, m_CameraZoom);
+        
+        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(5, 5));
+        ImGui::TextColored(ImVec4(0.8f, 0.8f, 1.0f, 1.0f), "Speed Multiplier:");
+        ImGui::SameLine();
+        ImGui::PushItemWidth(100);
+        ImGui::DragFloat("##Speed", &m_EditorSettings.SpeedMultiplier, 0.1f, 0.1f, 100.0f, "%.1f");
+        ImGui::PopItemWidth();
+        ImGui::PopStyleVar();
+
+        if (!m_EditorSettings.AllowNavigation)
+             ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), "Navigation: DISABLED");
+        else
+             ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "Navigation: RMB + WASD (Shift: Sprint | Scroll: Zoom | Shift+Scroll: Speed Multi)");
 
     ImGui::End();
     ImGui::PopStyleVar();
@@ -626,7 +654,7 @@ void EditorLayer::UI_DrawSettingsPanel()
     if (ImGui::CollapsingHeader("Viewport", ImGuiTreeNodeFlags_DefaultOpen))
     {
         ImGui::Checkbox("Show Physics Colliders", &m_EditorSettings.ShowPhysicsColliders);
-        ImGui::DragFloat("Camera Speed", &m_EditorSettings.CameraSpeed, 0.1f, 1.0f, 100.0f);
+        ImGui::DragFloat("Speed Multiplier", &m_EditorSettings.SpeedMultiplier, 0.1f, 0.1f, 100.0f);
         ImGui::DragFloat("Zoom Speed", &m_EditorSettings.ZoomSpeed, 0.1f, 0.1f, 10.0f);
     }
 
@@ -705,7 +733,8 @@ void EditorLayer::UpdateCamera(float dt)
 
     if (ImGui::IsMouseDown(ImGuiMouseButton_Right))
     {
-        float speed = m_EditorSettings.CameraSpeed * dt;
+        float sprintBonus = (Input::IsKeyPressed(Key::LeftShift) || Input::IsKeyPressed(Key::RightShift)) ? 2.5f : 1.0f;
+        float speed = (m_EditorSettings.BaseCameraSpeed * m_EditorSettings.SpeedMultiplier) * sprintBonus * dt;
 
         if (ImGui::IsKeyDown(ImGuiKey_W))
             m_CameraPosition.y += speed;
@@ -730,9 +759,18 @@ bool EditorLayer::OnMouseScrolled(MouseScrolledEvent &e)
 {
     if (m_ViewportHovered)
     {
-        m_CameraZoom -= e.GetYOffset() * 0.5f * m_EditorSettings.ZoomSpeed;
-        if (m_CameraZoom < 0.1f)
-            m_CameraZoom = 0.1f;
+        if (Input::IsKeyPressed(Key::LeftShift) || Input::IsKeyPressed(Key::RightShift))
+        {
+            m_EditorSettings.SpeedMultiplier += e.GetYOffset() * 0.1f;
+            if (m_EditorSettings.SpeedMultiplier < 0.1f) m_EditorSettings.SpeedMultiplier = 0.1f;
+            if (m_EditorSettings.SpeedMultiplier > 100.0f) m_EditorSettings.SpeedMultiplier = 100.0f;
+        }
+        else
+        {
+            m_CameraZoom -= e.GetYOffset() * 0.5f * m_EditorSettings.ZoomSpeed;
+            if (m_CameraZoom < 0.1f)
+                m_CameraZoom = 0.1f;
+        }
         return true;
     }
     return false;

--- a/Engine/src/Core/Layers/EditorLayer.cpp
+++ b/Engine/src/Core/Layers/EditorLayer.cpp
@@ -590,50 +590,54 @@ void EditorLayer::UI_DrawViewport()
                      ImVec2{1, 0});
     }
 
-        auto drawList = ImGui::GetWindowDrawList();
-        if (m_ShowViewport)
-        {
-            ImVec2 winPos = ImGui::GetWindowPos();
-            ImVec2 winSize = ImGui::GetWindowSize();
-            
-            // Base grid step at default zoom
-            float BASE_GRID_STEP = 64.0f;
-            // Scale grid step based on camera zoom relative to default
-            float visualGridStep = BASE_GRID_STEP * (m_EditorSettings.DefaultZoom / m_CameraZoom);
-            
-            // Subdivide or clump if grid gets too small/large
-            if (visualGridStep < 10.0f) visualGridStep *= 10.0f;
-            if (visualGridStep > 500.0f) visualGridStep /= 10.0f;
+    auto drawList = ImGui::GetWindowDrawList();
+    if (m_ShowViewport)
+    {
+        ImVec2 winPos = ImGui::GetWindowPos();
+        ImVec2 winSize = ImGui::GetWindowSize();
 
-            ImU32 gridColor = IM_COL32(200, 200, 200, 40);
+        // Base grid step at default zoom
+        float BASE_GRID_STEP = 64.0f;
+        // Scale grid step based on camera zoom relative to default
+        float visualGridStep = BASE_GRID_STEP * (m_EditorSettings.DefaultZoom / m_CameraZoom);
 
-            // Calculate scrolling offset based on camera position and zoom
-            float offsetX = fmodf(-m_CameraPosition.x * (m_EditorSettings.DefaultZoom / m_CameraZoom), visualGridStep);
-            float offsetY = fmodf(m_CameraPosition.y * (m_EditorSettings.DefaultZoom / m_CameraZoom), visualGridStep);
+        // Subdivide or clump if grid gets too small/large
+        if (visualGridStep < 10.0f)
+            visualGridStep *= 10.0f;
+        if (visualGridStep > 500.0f)
+            visualGridStep /= 10.0f;
 
-            for (float x = offsetX; x < winSize.x; x += visualGridStep)
-                drawList->AddLine(ImVec2(winPos.x + x, winPos.y), ImVec2(winPos.x + x, winPos.y + winSize.y), gridColor);
-            
-            for (float y = offsetY; y < winSize.y; y += visualGridStep)
-                drawList->AddLine(ImVec2(winPos.x, winPos.y + y), ImVec2(winPos.x + winSize.x, winPos.y + y), gridColor);
-        }
+        ImU32 gridColor = IM_COL32(200, 200, 200, 40);
 
-        ImGui::SetCursorPos(ImVec2(10, 30));
-        ImGui::TextColored(ImVec4(0.0f, 1.0f, 1.0f, 1.0f), "Viewport Size: %.0f, %.0f", m_LastViewportX, m_LastViewportY);
-        ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.0f, 1.0f), "Camera Pos: %.2f, %.2f | Zoom: %.2f", m_CameraPosition.x, m_CameraPosition.y, m_CameraZoom);
-        
-        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(5, 5));
-        ImGui::TextColored(ImVec4(0.8f, 0.8f, 1.0f, 1.0f), "Speed Multiplier:");
-        ImGui::SameLine();
-        ImGui::PushItemWidth(100);
-        ImGui::DragFloat("##Speed", &m_EditorSettings.SpeedMultiplier, 0.1f, 0.1f, 100.0f, "%.1f");
-        ImGui::PopItemWidth();
-        ImGui::PopStyleVar();
+        // Calculate scrolling offset based on camera position and zoom
+        float offsetX = fmodf(-m_CameraPosition.x * (m_EditorSettings.DefaultZoom / m_CameraZoom), visualGridStep);
+        float offsetY = fmodf(m_CameraPosition.y * (m_EditorSettings.DefaultZoom / m_CameraZoom), visualGridStep);
 
-        if (!m_EditorSettings.AllowNavigation)
-             ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), "Navigation: DISABLED");
-        else
-             ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "Navigation: RMB + WASD (Shift: Sprint | Scroll: Zoom | Shift+Scroll: Speed Multi)");
+        for (float x = offsetX; x < winSize.x; x += visualGridStep)
+            drawList->AddLine(ImVec2(winPos.x + x, winPos.y), ImVec2(winPos.x + x, winPos.y + winSize.y), gridColor);
+
+        for (float y = offsetY; y < winSize.y; y += visualGridStep)
+            drawList->AddLine(ImVec2(winPos.x, winPos.y + y), ImVec2(winPos.x + winSize.x, winPos.y + y), gridColor);
+    }
+
+    ImGui::SetCursorPos(ImVec2(10, 30));
+    ImGui::TextColored(ImVec4(0.0f, 1.0f, 1.0f, 1.0f), "Viewport Size: %.0f, %.0f", m_LastViewportX, m_LastViewportY);
+    ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.0f, 1.0f), "Camera Pos: %.2f, %.2f | Zoom: %.2f", m_CameraPosition.x,
+                       m_CameraPosition.y, m_CameraZoom);
+
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(5, 5));
+    ImGui::TextColored(ImVec4(0.8f, 0.8f, 1.0f, 1.0f), "Speed Multiplier:");
+    ImGui::SameLine();
+    ImGui::PushItemWidth(100);
+    ImGui::DragFloat("##Speed", &m_EditorSettings.SpeedMultiplier, 0.1f, 0.1f, 100.0f, "%.1f");
+    ImGui::PopItemWidth();
+    ImGui::PopStyleVar();
+
+    if (!m_EditorSettings.AllowNavigation)
+        ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), "Navigation: DISABLED");
+    else
+        ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f),
+                           "Navigation: RMB + WASD (Shift: Sprint | Scroll: Zoom | Shift+Scroll: Speed Multi)");
 
     ImGui::End();
     ImGui::PopStyleVar();
@@ -762,8 +766,10 @@ bool EditorLayer::OnMouseScrolled(MouseScrolledEvent &e)
         if (Input::IsKeyPressed(Key::LeftShift) || Input::IsKeyPressed(Key::RightShift))
         {
             m_EditorSettings.SpeedMultiplier += e.GetYOffset() * 0.1f;
-            if (m_EditorSettings.SpeedMultiplier < 0.1f) m_EditorSettings.SpeedMultiplier = 0.1f;
-            if (m_EditorSettings.SpeedMultiplier > 100.0f) m_EditorSettings.SpeedMultiplier = 100.0f;
+            if (m_EditorSettings.SpeedMultiplier < 0.1f)
+                m_EditorSettings.SpeedMultiplier = 0.1f;
+            if (m_EditorSettings.SpeedMultiplier > 100.0f)
+                m_EditorSettings.SpeedMultiplier = 100.0f;
         }
         else
         {


### PR DESCRIPTION
## Description
This PR enhances the editor viewport by providing better visual feedback for movement and zooming, which was previously difficult to perceive in empty scenes.

## Key Changes
- **Viewport HUD**: Added a persistent overlay in the top-left of the viewport showing current Camera Position and Zoom Level.
- **Refined Movement Speed**:
  - Movement now uses a base speed of 100 units/s.
  - Added a Speed Multiplier (0.1 - 100.0) editable via a slider in the viewport.
  - Added Shift + Mouse Wheel shortcut to adjust the multiplier on the fly.
  - Added Shift-Sprint (2.5x speed) while holding the Right Mouse Button and WASD.
- **Scaling Grid**: The background grid now scrolls with the camera and scales visually with zoom, providing clear feedback even when no objects are present.
- **Hierarchy Clarity**: Labeled the current placeholder entities in the Scene Hierarchy as (Mock) to distinguish them from active scene objects.

## Related Issues
Fixes several UX issues regarding "empty scene" navigation.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Style / Refactoring

## How Has This Been Tested?
- **Grid Scaling**: Verified that the grid lines move closer/farther as the zoom value changes.
- **HUD Accuracy**: Verified that coordinates update correctly when panning WASD.
- **Speed Controls**: Tested various multiplier values and confirmed the sprint bonus logic works as intended.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
