### PR TITLE
Docs: Convert absolute file URIs to GitHub relative links

### DIFF
--- a/.agents/rules/priority.md
+++ b/.agents/rules/priority.md
@@ -5,7 +5,6 @@ trigger: always_on
 # TimeEngine Development Priorities
 
 1. **Leverage Existing Systems**: Use established classes and types (`Texture2D`, `Ref<T>`, etc.) instead of re-implementing or using raw OpenGL.
-2. **Local Workflow**: Avoid using Chrome. Perform all searches and documentation lookups via the local environment or backend tools.
-3. **Build Validation**: Always verify changes by building the project:
-   `D:\Installed\VisualStudio\VisualStudioIDE\MSBuild\Current\Bin\amd64\MSBuild.exe Engine\Engine.vcxproj /p:Configuration=Debug /p:Platform=x64`
-4. **Offline-First Research**: Check local headers and project documentation (like `llms.txt`) before searching the web.
+2. **Local Workflow & Documentation Compliance**: Always follow local documentation and rules: `llms.md`, `llms.txt`, all `ARCHITECTURE.md` files across the codebase, and `.agentsrules`. Avoid using Chrome; perform searches and lookups locally.
+3. **Build & Test Validation**: For all build, test, and generation steps, strictly use project scripts only (e.g., scripts under `Scripts/Windows/MSVC/` such as `BuildDebug.bat`). Do not run direct MSBuild.exe commands.
+4. **Offline-First Research**: Check local headers and project documentation before searching external resources.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,12 +10,12 @@ This document provides a concise high-level architecture index and build configu
 ## 🏛️ Subsystem Architecture Guides
 
 * ⚙️ **[Engine Subsystem Architecture](Engine/ARCHITECTURE.md)** — Core engine loop, ECS, 2D physics, 2D collisions, asset manager, and multi-backend renderers (OpenGL 4.5, DirectX 11, Vulkan, OpenGLES).
-  * 📁 **[Project Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Core/Project/ARCHITECTURE.md)** — Active workspace config (`ProjectConfig`), root directory resolution, and `.teproj` serialization.
-  * ⚙️ **[Engine Settings Architecture](file:///e:/TimeEngine/Engine/Include/Core/EngineSettings_ARCHITECTURE.md)** — Singleton engine settings (`EngineSettings`), target framerates, VSync, logging filters, and UI layer.
-  * ⚡ **[Events Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Core/Events/ARCHITECTURE.md)** — Blocking event classes (`ApplicationEvent`, `KeyEvent`, `MouseEvent`) and type-safe `EventDispatcher`.
-  * 🧵 **[Multi-Threading & Task System Architecture](file:///e:/TimeEngine/Engine/Include/Core/Threading/ARCHITECTURE.md)** — Dedicated thread pools (`ThreadPool`, `TaskSystem`), 6 worker pools (Main, Render, Gameplay, AI, Calc, Widget), and async job macros (`SUBMIT_CALC`, `SUBMIT_AI`).
-  * 🥞 **[Layers Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Core/Layers/ARCHITECTURE.md)** — Modular execution stack (`LayerStack`), regular game layers vs top-priority GUI overlays.
-  * 🔌 **[Plugin Manager Architecture](file:///e:/TimeEngine/Engine/src/Core/Plugin/ARCHITECTURE.md)** — Dynamic OS library loader (`LoadLibraryW` / `dlopen`), `.teplugin` descriptor parser, and symbol factories.
+  * 📁 **[Project Subsystem Architecture](Engine/src/Core/Project/ARCHITECTURE.md)** — Active workspace config (`ProjectConfig`), root directory resolution, and `.teproj` serialization.
+  * ⚙️ **[Engine Settings Architecture](Engine/Include/Core/EngineSettings_ARCHITECTURE.md)** — Singleton engine settings (`EngineSettings`), target framerates, VSync, logging filters, and UI layer.
+  * ⚡ **[Events Subsystem Architecture](Engine/src/Core/Events/ARCHITECTURE.md)** — Blocking event classes (`ApplicationEvent`, `KeyEvent`, `MouseEvent`) and type-safe `EventDispatcher`.
+  * 🧵 **[Multi-Threading & Task System Architecture](Engine/Include/Core/Threading/ARCHITECTURE.md)** — Dedicated thread pools (`ThreadPool`, `TaskSystem`), 6 worker pools (Main, Render, Gameplay, AI, Calc, Widget), and async job macros (`SUBMIT_CALC`, `SUBMIT_AI`).
+  * 🥞 **[Layers Subsystem Architecture](Engine/src/Core/Layers/ARCHITECTURE.md)** — Modular execution stack (`LayerStack`), regular game layers vs top-priority GUI overlays.
+  * 🔌 **[Plugin Manager Architecture](Engine/src/Core/Plugin/ARCHITECTURE.md)** — Dynamic OS library loader (`LoadLibraryW` / `dlopen`), `.teplugin` descriptor parser, and symbol factories.
 * 📁 **[Engine Source Directory Index](Engine/src/ARCHITECTURE.md)** — Navigation index for `Engine/src/` subdirectories (`Core`, `Renderer`, `Editor`, `Input`, `Camera`, `Window`, `Utils`).
 * 🖥️ **[TimeEditor IGDE Architecture](TimeEditor/ARCHITECTURE.md)** — Visual editor workspace modes, asset inspectors, toolbar controls, and viewport rendering.
 * 🔌 **[Plugins Architecture](Engine/Plugins/ARCHITECTURE.md)** — Dynamic OS shared library (`.dll`/`.so`) plugin slot architecture.
@@ -25,7 +25,7 @@ This document provides a concise high-level architecture index and build configu
 
 ## 🛠️ Build System (`Premake5.lua`) & Build Commands
 
-TimeEngine uses **Premake5** ([`Premake5.lua`](file:///e:/TimeEngine/Premake5.lua)) to generate native Visual Studio solution files (`.sln`), Makefiles, or Ninja projects across Windows, Linux, and macOS.
+TimeEngine uses **Premake5** ([`Premake5.lua`](Premake5.lua)) to generate native Visual Studio solution files (`.sln`), Makefiles, or Ninja projects across Windows, Linux, and macOS.
 
 ### Building on Windows (MSVC / MSBuild)
 ```bash
@@ -49,11 +49,11 @@ make -j$(nproc)
 
 ## 📜 Automation & Tooling Scripts (`Scripts/`)
 
-* 🛠️ **[`Scripts/MCP_Tools.sh`](file:///e:/TimeEngine/Scripts/MCP_Tools.sh)** — CLI helper script mapping command-line tool calls to JSON-RPC 2.0 payloads for the embedded MCP server.
-* 🐍 **[`Scripts/parse_json.py`](file:///e:/TimeEngine/Scripts/parse_json.py)** — Python helper for constructing complex JSON entity mutation payloads.
-* 📦 **[`Scripts/SetupSubmodules.sh`](file:///e:/TimeEngine/Scripts/SetupSubmodules.sh)** — Automated Git submodule dependency fetcher.
-* 🪟 **[`Scripts/Windows/CleanProjectFiles.bat`](file:///e:/TimeEngine/Scripts/Windows/CleanProjectFiles.bat)** — Batch utility cleaning generated binaries (`Bin/`, `Bin-Intermediate/`).
-* 🔗 **[`Scripts/Windows/RegisterFileExtension.bat`](file:///e:/TimeEngine/Scripts/Windows/RegisterFileExtension.bat)** — Win32 script registering `.teproj` and `.tescene` file associations in Windows Registry.
+* 🛠️ **[`Scripts/MCP_Tools.sh`](Scripts/MCP_Tools.sh)** — CLI helper script mapping command-line tool calls to JSON-RPC 2.0 payloads for the embedded MCP server.
+* 🐍 **[`Scripts/parse_json.py`](Scripts/parse_json.py)** — Python helper for constructing complex JSON entity mutation payloads.
+* 📦 **[`Scripts/SetupSubmodules.sh`](Scripts/SetupSubmodules.sh)** — Automated Git submodule dependency fetcher.
+* 🪟 **[`Scripts/Windows/CleanProjectFiles.bat`](Scripts/Windows/CleanProjectFiles.bat)** — Batch utility cleaning generated binaries (`Bin/`, `Bin-Intermediate/`).
+* 🔗 **[`Scripts/Windows/RegisterFileExtension.bat`](Scripts/Windows/RegisterFileExtension.bat)** — Win32 script registering `.teproj` and `.tescene` file associations in Windows Registry.
 
 ---
 
@@ -63,10 +63,10 @@ To ensure long-term portability and maintainability, direct calls to third-party
 
 | Vendor Library | Wrapper Layer | Class / Header |
 | :--- | :--- | :--- |
-| **ImGui** | `TimeGUI` | [`TimeGUI.hpp`](file:///e:/TimeEngine/Engine/Include/Utils/TimeGUI.hpp) |
-| **GLM** | `MathUtils` | [`MathUtils.hpp`](file:///e:/TimeEngine/Engine/Include/Utils/MathUtils.hpp) |
-| **GLFW** | `IWindow` | [`IWindow.hpp`](file:///e:/TimeEngine/Engine/Include/Window/IWindow.hpp) |
-| **Velox / Physics** | `PhysicsWorld` | [`PhysicsWorld.hpp`](file:///e:/TimeEngine/Engine/Include/Core/Physics/PhysicsWorld.hpp) |
+| **ImGui** | `TimeGUI` | [`TimeGUI.hpp`](Engine/Include/Utils/TimeGUI.hpp) |
+| **GLM** | `MathUtils` | [`MathUtils.hpp`](Engine/Include/Utils/MathUtils.hpp) |
+| **GLFW** | `IWindow` | [`IWindow.hpp`](Engine/Include/Window/IWindow.hpp) |
+| **Velox / Physics** | `PhysicsWorld` | [`PhysicsWorld.hpp`](Engine/Include/Core/Physics/PhysicsWorld.hpp) |
 
 ---
 
@@ -74,3 +74,4 @@ To ensure long-term portability and maintainability, direct calls to third-party
 
 * 📄 **[ROADMAP.md](ROADMAP.md)** — Feature milestones and deterministic time-manipulation engine plans.
 * 🤖 **[llms.txt](llms.txt)** / **[llms.md](llms.md)** — Architectural reference file for AI coding assistants.
+

--- a/Engine/ARCHITECTURE.md
+++ b/Engine/ARCHITECTURE.md
@@ -31,37 +31,38 @@ TimeEngine/
 Each link below opens a detailed, dedicated architectural reference document:
 
 ### 1. Engine Core Subsystems
-* 🏠 **[Engine Source Directory Index](file:///e:/TimeEngine/Engine/src/ARCHITECTURE.md)** — Master index for all `Engine/src/` subdirectories.
-* ⚙️ **[Core Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Core/ARCHITECTURE.md)** — Main engine loop (`Application`), thread pools, ECS, physics, assets, events, layer stack, and plugins.
-  * 🎬 **[Scene & ECS Architecture](file:///e:/TimeEngine/Engine/src/Core/Scene/ARCHITECTURE.md)** — Entity lifespan (`EntityManager`), components, `.tescene` serialization, and runtime playback.
-  * ⚛️ **[2D Physics Architecture](file:///e:/TimeEngine/Engine/src/Core/Physics/ARCHITECTURE.md)** — Rigid body dynamics (`RigidBody`), Symplectic Euler integration, 2D joints, and soft bodies.
-  * 💥 **[2D Collision Architecture](file:///e:/TimeEngine/Engine/src/Core/Collision/ARCHITECTURE.md)** — Broadphase spatial pair filtering (`BroadPhase`) and SAT narrowphase overlap checks (`CollisionSystem`).
-  * 📦 **[Asset Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Core/Asset/ARCHITECTURE.md)** — 64-bit `AssetHandle` mappings, path registry (`AssetRegistry`), prototype metadata, and image I/O.
-  * 🎮 **[GameFramework Architecture](file:///e:/TimeEngine/Engine/src/Core/GameFrameWork/ARCHITECTURE.md)** — Reflected base object (`TObject`), spatial component (`TComponent`), hierarchy, picking, and object pooling.
-  * ⚡ **[Events Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Core/Events/ARCHITECTURE.md)** — Blocking event classes (`ApplicationEvent`, `KeyEvent`, `MouseEvent`) and type-safe `EventDispatcher`.
-  * 🥞 **[Layers Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Core/Layers/ARCHITECTURE.md)** — Modular execution stack (`LayerStack`), regular game layers vs top-priority GUI overlays.
-  * 🎮 **[Core Low-Level Input Architecture](file:///e:/TimeEngine/Engine/src/Core/Input/ARCHITECTURE.md)** — Hardware polling (`Input`), key hold duration timers (`InputState`), and scroll accumulators.
-  * ⏱️ **[Core Time Architecture](file:///e:/TimeEngine/Engine/src/Core/Time/ARCHITECTURE.md)** — Frame delta calculation, fixed metronome tickers (`Ticker`), and static delayed timers (`Timer`).
-  * 📁 **[Project Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Core/Project/ARCHITECTURE.md)** — Active workspace config (`ProjectConfig`), root directory resolution, and `.teproj` serialization.
-  * 🔌 **[Plugin Manager Architecture](file:///e:/TimeEngine/Engine/src/Core/Plugin/ARCHITECTURE.md)** — Dynamic OS library loader (`LoadLibraryW` / `dlopen`), `.teplugin` descriptor parser, and symbol factories.
+* 🏠 **[Engine Source Directory Index](src/ARCHITECTURE.md)** — Master index for all `Engine/src/` subdirectories.
+* ⚙️ **[Core Subsystem Architecture](src/Core/ARCHITECTURE.md)** — Main engine loop (`Application`), thread pools, ECS, physics, assets, events, layer stack, and plugins.
+  * 🎬 **[Scene & ECS Architecture](src/Core/Scene/ARCHITECTURE.md)** — Entity lifespan (`EntityManager`), components, `.tescene` serialization, and runtime playback.
+  * ⚛️ **[2D Physics Architecture](src/Core/Physics/ARCHITECTURE.md)** — Rigid body dynamics (`RigidBody`), Symplectic Euler integration, 2D joints, and soft bodies.
+  * 💥 **[2D Collision Architecture](src/Core/Collision/ARCHITECTURE.md)** — Broadphase spatial pair filtering (`BroadPhase`) and SAT narrowphase overlap checks (`CollisionSystem`).
+  * 📦 **[Asset Subsystem Architecture](src/Core/Asset/ARCHITECTURE.md)** — 64-bit `AssetHandle` mappings, path registry (`AssetRegistry`), prototype metadata, and image I/O.
+  * 🎮 **[GameFramework Architecture](src/Core/GameFrameWork/ARCHITECTURE.md)** — Reflected base object (`TObject`), spatial component (`TComponent`), hierarchy, picking, and object pooling.
+  * ⚡ **[Events Subsystem Architecture](src/Core/Events/ARCHITECTURE.md)** — Blocking event classes (`ApplicationEvent`, `KeyEvent`, `MouseEvent`) and type-safe `EventDispatcher`.
+  * 🥞 **[Layers Subsystem Architecture](src/Core/Layers/ARCHITECTURE.md)** — Modular execution stack (`LayerStack`), regular game layers vs top-priority GUI overlays.
+  * 🎮 **[Core Low-Level Input Architecture](src/Core/Input/ARCHITECTURE.md)** — Hardware polling (`Input`), key hold duration timers (`InputState`), and scroll accumulators.
+  * ⏱️ **[Core Time Architecture](src/Core/Time/ARCHITECTURE.md)** — Frame delta calculation, fixed metronome tickers (`Ticker`), and static delayed timers (`Timer`).
+  * 📁 **[Project Subsystem Architecture](src/Core/Project/ARCHITECTURE.md)** — Active workspace config (`ProjectConfig`), root directory resolution, and `.teproj` serialization.
+  * 🔌 **[Plugin Manager Architecture](src/Core/Plugin/ARCHITECTURE.md)** — Dynamic OS library loader (`LoadLibraryW` / `dlopen`), `.teplugin` descriptor parser, and symbol factories.
 
 ### 2. Graphics & Rendering Subsystems
-* 🎨 **[Renderer Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Renderer/ARCHITECTURE.md)** — 2D batching pipeline (`Renderer2D`, `RenderBatcher`), 2D lights, shadow volumes, materials, and shaders.
-  * 🟢 **[OpenGL Backend Architecture](file:///e:/TimeEngine/Engine/src/Renderer/OpenGL/ARCHITECTURE.md)** — Cross-platform desktop OpenGL 4.5 DSA hardware renderer implementation.
-  * 🔷 **[DirectX 11 Backend Architecture](file:///e:/TimeEngine/Engine/src/Renderer/DirectX11/ARCHITECTURE.md)** — Direct3D 11 hardware backend implementation (`DX11Context`, D3DCompile HLSL shaders).
-  * 📱 **[OpenGL ES Backend Architecture](file:///e:/TimeEngine/Engine/src/Renderer/OpenGLES/ARCHITECTURE.md)** — Embedded & mobile OpenGL ES 3.0 hardware backend implementation.
-  * 🌋 **[Vulkan Backend Architecture](file:///e:/TimeEngine/Engine/src/Renderer/Vulkan/ARCHITECTURE.md)** — Explicit Vulkan 1.3 low-overhead hardware backend implementation (`volk`, SPIR-V).
-  * 🎨 **[Material System Architecture](file:///e:/TimeEngine/Engine/src/Renderer/Material/ARCHITECTURE.md)** — Node-based material pass stack (`MaterialPassNode`), uniform caching, and `.tematerial` serialization.
+* 🎨 **[Renderer Subsystem Architecture](src/Renderer/ARCHITECTURE.md)** — 2D batching pipeline (`Renderer2D`, `RenderBatcher`), 2D lights, shadow volumes, materials, and shaders.
+  * 🟢 **[OpenGL Backend Architecture](src/Renderer/OpenGL/ARCHITECTURE.md)** — Cross-platform desktop OpenGL 4.5 DSA hardware renderer implementation.
+  * 🔷 **[DirectX 11 Backend Architecture](src/Renderer/DirectX11/ARCHITECTURE.md)** — Direct3D 11 hardware backend implementation (`DX11Context`, D3DCompile HLSL shaders).
+  * 📱 **[OpenGL ES Backend Architecture](src/Renderer/OpenGLES/ARCHITECTURE.md)** — Embedded & mobile OpenGL ES 3.0 hardware backend implementation.
+  * 🌋 **[Vulkan Backend Architecture](src/Renderer/Vulkan/ARCHITECTURE.md)** — Explicit Vulkan 1.3 low-overhead hardware backend implementation (`volk`, SPIR-V).
+  * 🎨 **[Material System Architecture](src/Renderer/Material/ARCHITECTURE.md)** — Node-based material pass stack (`MaterialPassNode`), uniform caching, and `.tematerial` serialization.
 
 ### 3. Engine Tools, Viewport & Windowing
-* 🛠️ **[Editor Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Editor/ARCHITECTURE.md)** — Visual editor workspace modes (`EditorModeRegistry`), specialized asset inspectors (`AssetEditorRegistry`), and toolbars.
-* 🎯 **[High-Level Input Architecture](file:///e:/TimeEngine/Engine/src/Input/ARCHITECTURE.md)** — Action mapping contexts (`InputSystem`, `InputAction`, `InputMappingContext`), priority contexts, and `InputComponent`.
-* 📷 **[Camera Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Camera/ARCHITECTURE.md)** — 2D/3D camera matrix calculation (`Camera`), `OrthographicCamera`, `PerspectiveCamera`, and `PlayerCameraComponent`.
-* 🖥️ **[Window Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Window/ARCHITECTURE.md)** — Native window abstraction (`IWindow`, `WindowsWindow`), GLFW callbacks, VSync, and swap chain buffers.
-* 🧰 **[Utils Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Utils/ARCHITECTURE.md)** — Core engine toolbox, 2D engine math primitives (`MathUtils`), vendor-agnostic GUI wrappers (`TimeGUI`), and OS platform utilities.
-  * 🪟 **[Win32 Platform Architecture](file:///e:/TimeEngine/Engine/src/Utils/Platform/Windows/ARCHITECTURE.md)** — Win32 file dialogs (`IFileDialog`), HKCU Windows Registry associations, and executable path resolution.
-  * 🐧 **[Unix Platform Architecture](file:///e:/TimeEngine/Engine/src/Utils/Platform/Unix/ARCHITECTURE.md)** — POSIX executable path resolution (`/proc/self/exe`), native Unix dialogs, and MIME registrations.
+* 🛠️ **[Editor Subsystem Architecture](src/Editor/ARCHITECTURE.md)** — Visual editor workspace modes (`EditorModeRegistry`), specialized asset inspectors (`AssetEditorRegistry`), and toolbars.
+* 🎯 **[High-Level Input Architecture](src/Input/ARCHITECTURE.md)** — Action mapping contexts (`InputSystem`, `InputAction`, `InputMappingContext`), priority contexts, and `InputComponent`.
+* 📷 **[Camera Subsystem Architecture](src/Camera/ARCHITECTURE.md)** — 2D/3D camera matrix calculation (`Camera`), `OrthographicCamera`, `PerspectiveCamera`, and `PlayerCameraComponent`.
+* 🖥️ **[Window Subsystem Architecture](src/Window/ARCHITECTURE.md)** — Native window abstraction (`IWindow`, `WindowsWindow`), GLFW callbacks, VSync, and swap chain buffers.
+* 🧰 **[Utils Subsystem Architecture](src/Utils/ARCHITECTURE.md)** — Core engine toolbox, 2D engine math primitives (`MathUtils`), vendor-agnostic GUI wrappers (`TimeGUI`), and OS platform utilities.
+  * 🪟 **[Win32 Platform Architecture](src/Utils/Platform/Windows/ARCHITECTURE.md)** — Win32 file dialogs (`IFileDialog`), HKCU Windows Registry associations, and executable path resolution.
+  * 🐧 **[Unix Platform Architecture](src/Utils/Platform/Unix/ARCHITECTURE.md)** — POSIX executable path resolution (`/proc/self/exe`), native Unix dialogs, and MIME registrations.
 
 ### 4. Engine Plugins
-* 🔌 **[Plugins Subsystem Architecture](file:///e:/TimeEngine/Engine/Plugins/ARCHITECTURE.md)** — Engine dynamic plugin slot architecture and dynamic extension loading guidelines.
-  * 🤖 **[MCP Plugin Architecture](file:///e:/TimeEngine/Engine/Plugins/MCPPlugin/ARCHITECTURE.md)** — Model Context Protocol HTTP/SSE server plugin listening on port `3000` for remote AI engine automation.
+* 🔌 **[Plugins Subsystem Architecture](Plugins/ARCHITECTURE.md)** — Engine dynamic plugin slot architecture and dynamic extension loading guidelines.
+  * 🤖 **[MCP Plugin Architecture](Plugins/MCPPlugin/ARCHITECTURE.md)** — Model Context Protocol HTTP/SSE server plugin listening on port `3000` for remote AI engine automation.
+

--- a/Engine/Include/Core/ARCHITECTURE.md
+++ b/Engine/Include/Core/ARCHITECTURE.md
@@ -6,8 +6,8 @@ This directory contains the public header interfaces, memory models, thread pool
 
 ## 🏛️ Subsystem Architecture Guides & Direct Links
 
-* 🧵 **[Multi-Threading & Task System Architecture](file:///e:/TimeEngine/Engine/Include/Core/Threading/ARCHITECTURE.md)** (`Engine/Include/Core/Threading/`) — Dedicated worker thread pools (`ThreadPool`, `TaskSystem`), 6 task queues (Main, Render, Gameplay, AI, Calc, Widget), and async job submission macros (`SUBMIT_CALC`, `SUBMIT_AI`).
-* ⚙️ **[Engine Settings Architecture](file:///e:/TimeEngine/Engine/Include/Core/EngineSettings_ARCHITECTURE.md)** (`Engine/Include/Core/EngineSettings_ARCHITECTURE.md`) — Singleton engine configuration (`EngineSettings`), target framerates, VSync, logging filters, performance caps, and `EngineSettingsLayer`.
+* 🧵 **[Multi-Threading & Task System Architecture](Threading/ARCHITECTURE.md)** (`Engine/Include/Core/Threading/`) — Dedicated worker thread pools (`ThreadPool`, `TaskSystem`), 6 task queues (Main, Render, Gameplay, AI, Calc, Widget), and async job submission macros (`SUBMIT_CALC`, `SUBMIT_AI`).
+* ⚙️ **[Engine Settings Architecture](EngineSettings_ARCHITECTURE.md)** (`Engine/Include/Core/EngineSettings_ARCHITECTURE.md`) — Singleton engine configuration (`EngineSettings`), target framerates, VSync, logging filters, performance caps, and `EngineSettingsLayer`.
 
 ---
 
@@ -15,10 +15,11 @@ This directory contains the public header interfaces, memory models, thread pool
 
 For detailed C++ implementation docs, refer to the corresponding source architecture references:
 
-* ⚙️ **[Core Master Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Core/ARCHITECTURE.md)** — Main engine loop (`Application`), event callbacks, and layer stack processing.
-* 🎬 **[Scene & ECS Architecture](file:///e:/TimeEngine/Engine/src/Core/Scene/ARCHITECTURE.md)** — Entity-Component-System (`EntityManager`, `Entity`, `TComponent`).
-* ⚛️ **[2D Physics Architecture](file:///e:/TimeEngine/Engine/src/Core/Physics/ARCHITECTURE.md)** — Rigid body dynamics (`RigidBody`) and 2D constraint joints.
-* 💥 **[2D Collision Architecture](file:///e:/TimeEngine/Engine/src/Core/Collision/ARCHITECTURE.md)** — Broadphase pair filtering (`BroadPhase`) and SAT narrowphase overlap checks (`CollisionSystem`).
-* 📦 **[Asset Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Core/Asset/ARCHITECTURE.md)** — 64-bit `AssetHandle` mappings and path registry (`AssetRegistry`).
-* 🎮 **[GameFramework Architecture](file:///e:/TimeEngine/Engine/src/Core/GameFrameWork/ARCHITECTURE.md)** — Base object reflection (`TObject`) and spatial components (`TComponent`).
-* 🔌 **[Plugin Manager Architecture](file:///e:/TimeEngine/Engine/src/Core/Plugin/ARCHITECTURE.md)** — Dynamic OS library loader (`LoadLibraryW` / `dlopen`) and `.teplugin` parser.
+* ⚙️ **[Core Master Subsystem Architecture](../../src/Core/ARCHITECTURE.md)** — Main engine loop (`Application`), event callbacks, and layer stack processing.
+* 🎬 **[Scene & ECS Architecture](../../src/Core/Scene/ARCHITECTURE.md)** — Entity-Component-System (`EntityManager`, `Entity`, `TComponent`).
+* ⚛️ **[2D Physics Architecture](../../src/Core/Physics/ARCHITECTURE.md)** — Rigid body dynamics (`RigidBody`) and 2D constraint joints.
+* 💥 **[2D Collision Architecture](../../src/Core/Collision/ARCHITECTURE.md)** — Broadphase pair filtering (`BroadPhase`) and SAT narrowphase overlap checks (`CollisionSystem`).
+* 📦 **[Asset Subsystem Architecture](../../src/Core/Asset/ARCHITECTURE.md)** — 64-bit `AssetHandle` mappings and path registry (`AssetRegistry`).
+* 🎮 **[GameFramework Architecture](../../src/Core/GameFrameWork/ARCHITECTURE.md)** — Base object reflection (`TObject`) and spatial components (`TComponent`).
+* 🔌 **[Plugin Manager Architecture](../../src/Core/Plugin/ARCHITECTURE.md)** — Dynamic OS library loader (`LoadLibraryW` / `dlopen`) and `.teplugin` parser.
+

--- a/Engine/Include/Core/EngineSettings_ARCHITECTURE.md
+++ b/Engine/Include/Core/EngineSettings_ARCHITECTURE.md
@@ -84,7 +84,8 @@ settings.ResetToDefaults();
 
 ## Related Architectural Documentation
 
-- [Core Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Core/ARCHITECTURE.md) — Main engine application execution loop.
-- [Multi-Threading & Task System Architecture](file:///e:/TimeEngine/Engine/Include/Core/Threading/ARCHITECTURE.md) — Worker thread pools and task queues.
-- [Layers Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Core/Layers/ARCHITECTURE.md) — `EngineSettingsLayer` and overlay rendering.
-- [Root Architecture Index](file:///e:/TimeEngine/ARCHITECTURE.md) — Master TimeEngine architecture index.
+- [Core Subsystem Architecture](../../src/Core/ARCHITECTURE.md) — Main engine application execution loop.
+- [Multi-Threading & Task System Architecture](Threading/ARCHITECTURE.md) — Worker thread pools and task queues.
+- [Layers Subsystem Architecture](../../src/Core/Layers/ARCHITECTURE.md) — `EngineSettingsLayer` and overlay rendering.
+- [Root Architecture Index](../../../ARCHITECTURE.md) — Master TimeEngine architecture index.
+

--- a/Engine/Include/Core/Threading/ARCHITECTURE.md
+++ b/Engine/Include/Core/Threading/ARCHITECTURE.md
@@ -83,6 +83,7 @@ SUBMIT_AI([npcEntity]() {
 
 ## Related Architectural Documentation
 
-- [Core Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Core/ARCHITECTURE.md) — Main engine application loop.
-- [2D Physics Architecture](file:///e:/TimeEngine/Engine/src/Core/Physics/ARCHITECTURE.md) — Asynchronous physics integration.
-- [Root Architecture Index](file:///e:/TimeEngine/ARCHITECTURE.md) — Master TimeEngine architecture hub.
+- [Core Subsystem Architecture](../../../src/Core/ARCHITECTURE.md) — Main engine application loop.
+- [2D Physics Architecture](../../../src/Core/Physics/ARCHITECTURE.md) — Asynchronous physics integration.
+- [Root Architecture Index](../../../../ARCHITECTURE.md) — Master TimeEngine architecture hub.
+

--- a/Engine/Plugins/ARCHITECTURE.md
+++ b/Engine/Plugins/ARCHITECTURE.md
@@ -43,5 +43,6 @@ void MCPPlugin::OnUnload() {
 
 ## Registered Plugins & Architectures
 
-- [MCPPlugin](file:///e:/TimeEngine/Engine/Plugins/MCPPlugin/ARCHITECTURE.md) — Model Context Protocol (MCP) HTTP/SSE Server Plugin architecture documentation.
+- [MCPPlugin Architecture](MCPPlugin/ARCHITECTURE.md) — Model Context Protocol (MCP) HTTP/SSE Server Plugin architecture documentation.
+
 

--- a/Engine/Plugins/MCPPlugin/ARCHITECTURE.md
+++ b/Engine/Plugins/MCPPlugin/ARCHITECTURE.md
@@ -55,12 +55,13 @@ The `MCPPlugin` module provides a Model Context Protocol (MCP) HTTP/SSE server (
 
 Tools exposed by `MCPPlugin` can be called either directly via HTTP POST requests to `http://127.0.0.1:3000/message` carrying JSON-RPC 2.0 payloads or through the provided CLI wrapper script:
 
-- **Shell Wrapper**: [`Scripts/MCP_Tools.sh`](file:///e:/TimeEngine/Scripts/MCP_Tools.sh)
+- **Shell Wrapper**: [`Scripts/MCP_Tools.sh`](../../../Scripts/MCP_Tools.sh)
   - Usage: `./Scripts/MCP_Tools.sh <command_name> [args...]`
   - Maps simplified CLI commands to JSON-RPC 2.0 tool requests via `curl`.
   - Commands include `info`, `get_scene`, `create_entity <name>`, `destroy_entity <id>`, `create_sprite <name> <path>`, `mkdir <path>`, `rm <path>`, `get_modes`, `set_mode <name>`, `screenshot`, `delete_screenshot`, `send_key <code>`, `send_click <code>`, `select <id>`, `set_properties <id> <json>`, and `add_component <id> <type>`.
 
-- **JSON Helper**: Uses [`Scripts/parse_json.py`](file:///e:/TimeEngine/Scripts/parse_json.py) for constructing structured JSON property payloads for complex entity modifications.
+- **JSON Helper**: Uses [`Scripts/parse_json.py`](../../../Scripts/parse_json.py) for constructing structured JSON property payloads for complex entity modifications.
+
 
 ## Provided MCP Tools & Function Handlers
 

--- a/Engine/src/ARCHITECTURE.md
+++ b/Engine/src/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # TimeEngine `Engine/src` Subsystem Architecture Directory
 
-This document serves as the master navigation index for all subsystem architectures located inside the [`Engine/src/`](file:///e:/TimeEngine/Engine/src) directory.
+This document serves as the master navigation index for all subsystem architectures located inside the `Engine/src/` directory.
 
 ---
 
@@ -8,20 +8,20 @@ This document serves as the master navigation index for all subsystem architectu
 
 Each link below redirects to the detailed, dedicated architecture document for that specific engine subsystem:
 
-* ⚙️ **[Core Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Core/ARCHITECTURE.md)** (`Engine/src/Core/`) — Central engine loop (`Application`), multi-threading pools, ECS (`Scene`, `EntityManager`), 2D physics, 2D collisions, asset management (`AssetManager`), game framework (`TObject`, `TComponent`), events, layer stack, and dynamic plugin loading.
-* 🎨 **[Renderer Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Renderer/ARCHITECTURE.md)** (`Engine/src/Renderer/`) — Multi-backend graphics abstraction (OpenGL, DX11, Vulkan, OpenGLES), 2D batching (`Renderer2D`, `RenderBatcher`), 2D lights, shadow volumes, materials, shaders, and framebuffers.
-* 🛠️ **[Editor Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Editor/ARCHITECTURE.md)** (`Engine/src/Editor/`) — Visual development workspace, editor modes (`EditorModeRegistry`), specialized asset editing tabs (`AssetEditorRegistry`), and toolbar controls.
-* 🎯 **[Input Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Input/ARCHITECTURE.md)** (`Engine/src/Input/`) — High-level action mapping context system (`InputSystem`, `InputAction`, `InputMappingContext`), priority contexts, and entity binding callbacks (`InputComponent`).
-* 📷 **[Camera Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Camera/ARCHITECTURE.md)** (`Engine/src/Camera/`) — 2D/3D camera matrix calculation (`Camera`), 2D orthographic projection (`OrthographicCamera`), 3D perspective projection (`PerspectiveCamera`), controllers, and player tracking (`PlayerCameraComponent`).
-* 🖥️ **[Window Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Window/ARCHITECTURE.md)** (`Engine/src/Window/`) — OS native window abstraction (`IWindow`), window creation (`WindowsWindow`), GLFW event hooks, VSync toggles, and swap chain buffer swapping.
-* 🧰 **[Utils Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Utils/ARCHITECTURE.md)** (`Engine/src/Utils/`) — Core engine toolbox, 2D engine math primitives (`MathUtils`), vendor-agnostic GUI wrappers (`TimeGUI`), and OS-specific platform file/registry utilities.
-
+* ⚙️ **[Core Subsystem Architecture](Core/ARCHITECTURE.md)** (`Engine/src/Core/`) — Central engine loop (`Application`), multi-threading pools, ECS (`Scene`, `EntityManager`), 2D physics, 2D collisions, asset management (`AssetManager`), game framework (`TObject`, `TComponent`), events, layer stack, and dynamic plugin loading.
+* 🎨 **[Renderer Subsystem Architecture](Renderer/ARCHITECTURE.md)** (`Engine/src/Renderer/`) — Multi-backend graphics abstraction (OpenGL, DX11, Vulkan, OpenGLES), 2D batching (`Renderer2D`, `RenderBatcher`), 2D lights, shadow volumes, materials, shaders, and framebuffers.
+* 🛠️ **[Editor Subsystem Architecture](Editor/ARCHITECTURE.md)** (`Engine/src/Editor/`) — Visual development workspace, editor modes (`EditorModeRegistry`), specialized asset editing tabs (`AssetEditorRegistry`), and toolbar controls.
+* 🎯 **[Input Subsystem Architecture](Input/ARCHITECTURE.md)** (`Engine/src/Input/`) — High-level action mapping context system (`InputSystem`, `InputAction`, `InputMappingContext`), priority contexts, and entity binding callbacks (`InputComponent`).
+* 📷 **[Camera Subsystem Architecture](Camera/ARCHITECTURE.md)** (`Engine/src/Camera/`) — 2D/3D camera matrix calculation (`Camera`), 2D orthographic projection (`OrthographicCamera`), 3D perspective projection (`PerspectiveCamera`), controllers, and player tracking (`PlayerCameraComponent`).
+* 🖥️ **[Window Subsystem Architecture](Window/ARCHITECTURE.md)** (`Engine/src/Window/`) — OS native window abstraction (`IWindow`), window creation (`WindowsWindow`), GLFW event hooks, VSync toggles, and swap chain buffer swapping.
+* 🧰 **[Utils Subsystem Architecture](Utils/ARCHITECTURE.md)** (`Engine/src/Utils/`) — Core engine toolbox, 2D engine math primitives (`MathUtils`), vendor-agnostic GUI wrappers (`TimeGUI`), and OS-specific platform file/registry utilities.
 
 ---
 
 ## Related Root Architecture References
 
-- [Plugins Architecture](file:///e:/TimeEngine/Engine/Plugins/ARCHITECTURE.md) — Architecture for engine plugins and dynamic runtime extensions.
-- [MCP Plugin Architecture](file:///e:/TimeEngine/Engine/Plugins/MCPPlugin/ARCHITECTURE.md) — Remote-control Model Context Protocol HTTP/SSE AI receiver plugin.
-- [Windows Platform Utilities Architecture](file:///e:/TimeEngine/Engine/src/Utils/Platform/Windows/ARCHITECTURE.md) — Win32 file dialogs and registry helpers.
-- [Unix Platform Utilities Architecture](file:///e:/TimeEngine/Engine/src/Utils/Platform/Unix/ARCHITECTURE.md) — POSIX executable resolution and Unix dialogs.
+- [Plugins Architecture](../Plugins/ARCHITECTURE.md) — Architecture for engine plugins and dynamic runtime extensions.
+- [MCP Plugin Architecture](../Plugins/MCPPlugin/ARCHITECTURE.md) — Remote-control Model Context Protocol HTTP/SSE AI receiver plugin.
+- [Windows Platform Utilities Architecture](Utils/Platform/Windows/ARCHITECTURE.md) — Win32 file dialogs and registry helpers.
+- [Unix Platform Utilities Architecture](Utils/Platform/Unix/ARCHITECTURE.md) — POSIX executable resolution and Unix dialogs.
+

--- a/Engine/src/Core/ARCHITECTURE.md
+++ b/Engine/src/Core/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # TimeEngine Core Subsystem Architecture
 
-The **Core Subsystem** is the central engine hub of TimeEngine. It drives the main application execution loop ([`Application`](file:///e:/TimeEngine/Engine/src/Core/Application.h)), multi-threaded worker thread pool initialization, window event callbacks, layer stack updates, immediate-mode GUI rendering passes, and coordinates all sub-engine modules.
+The **Core Subsystem** is the central engine hub of TimeEngine. It drives the main application execution loop (`Application`), multi-threaded worker thread pool initialization, window event callbacks, layer stack updates, immediate-mode GUI rendering passes, and coordinates all sub-engine modules.
 
 > [!NOTE]
 > In short, think of **Core** as the main brain and engine chassis of TimeEngine: `Application` instantiates the OS window, initializes logging and thread pools, boots up the dynamic plugin manager (`PluginManager`), and loops continuously—updating game logic, rendering framebuffers, handling window events, and ticking timers.
@@ -37,24 +37,20 @@ The **Core Subsystem** is the central engine hub of TimeEngine. It drives the ma
 
 Click any module link below to open its comprehensive architectural reference:
 
-* 🎬 **[Scene & ECS Architecture](file:///e:/TimeEngine/Engine/src/Core/Scene/ARCHITECTURE.md)** — Entity-Component-System container (`EntityManager`), component lifecycle, JSON scene serialization (`.tescene`), and `Scene::OnUpdateRuntime`.
-* ⚛️ **[2D Physics Architecture](file:///e:/TimeEngine/Engine/src/Core/Physics/ARCHITECTURE.md)** — Rigid body dynamics (`RigidBody`), Symplectic Euler integration, raycasting, soft body node blobs, and 2D constraint joints.
-* 💥 **[2D Collision Architecture](file:///e:/TimeEngine/Engine/src/Core/Collision/ARCHITECTURE.md)** — Broadphase spatial pair filtering (`BroadPhase`), narrowphase Separating Axis Theorem (SAT) geometry checks (`CollisionSystem`), and collider components.
-* 📦 **[Asset Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Core/Asset/ARCHITECTURE.md)** — 64-bit `AssetHandle` mappings, path-handle registry (`AssetRegistry`), prototype metadata registration (`AssetManager`), and `stb_image` I/O.
-* 🎮 **[GameFramework Architecture](file:///e:/TimeEngine/Engine/src/Core/GameFrameWork/ARCHITECTURE.md)** — Base reflected game object (`TObject`), 2D spatial component (`TComponent`), hierarchy nesting, mouse picking (`ContainsPoint`), 2D shadow occlusion, and `StandardGameLibrary` object pooling.
-* ⚡ **[Events Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Core/Events/ARCHITECTURE.md)** — Blocking event classes (`ApplicationEvent`, `KeyEvent`, `MouseEvent`), category bitmasks, and type-safe event dispatching (`EventDispatcher`).
-* 🧵 **[Multi-Threading & Task System Architecture](file:///e:/TimeEngine/Engine/Include/Core/Threading/ARCHITECTURE.md)** — Dedicated thread pools (`ThreadPool`, `TaskSystem`), 6 worker pools (Main, Render, Gameplay, AI, Calc, Widget), and async job macros (`SUBMIT_CALC`, `SUBMIT_AI`).
-* 🥞 **[Layers Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Core/Layers/ARCHITECTURE.md)** — Modular execution stack (`LayerStack`), regular game layers vs top-priority GUI overlays, deferred removals/additions, and event propagation pipelines.
+* 🎬 **[Scene & ECS Architecture](Scene/ARCHITECTURE.md)** — Entity-Component-System container (`EntityManager`), component lifecycle, JSON scene serialization (`.tescene`), and `Scene::OnUpdateRuntime`.
+* ⚛️ **[2D Physics Architecture](Physics/ARCHITECTURE.md)** — Rigid body dynamics (`RigidBody`), Symplectic Euler integration, raycasting, soft body node blobs, and 2D constraint joints.
+* 💥 **[2D Collision Architecture](Collision/ARCHITECTURE.md)** — Broadphase spatial pair filtering (`BroadPhase`), narrowphase Separating Axis Theorem (SAT) geometry checks (`CollisionSystem`), and collider components.
+* 📦 **[Asset Subsystem Architecture](Asset/ARCHITECTURE.md)** — 64-bit `AssetHandle` mappings, path-handle registry (`AssetRegistry`), prototype metadata registration (`AssetManager`), and `stb_image` I/O.
+* 🎮 **[GameFramework Architecture](GameFrameWork/ARCHITECTURE.md)** — Base reflected game object (`TObject`), 2D spatial component (`TComponent`), hierarchy nesting, mouse picking (`ContainsPoint`), 2D shadow occlusion, and `StandardGameLibrary` object pooling.
+* ⚡ **[Events Subsystem Architecture](Events/ARCHITECTURE.md)** — Blocking event classes (`ApplicationEvent`, `KeyEvent`, `MouseEvent`), category bitmasks, and type-safe event dispatching (`EventDispatcher`).
+* 🧵 **[Multi-Threading & Task System Architecture](../../Include/Core/Threading/ARCHITECTURE.md)** — Dedicated thread pools (`ThreadPool`, `TaskSystem`), 6 worker pools (Main, Render, Gameplay, AI, Calc, Widget), and async job macros (`SUBMIT_CALC`, `SUBMIT_AI`).
+* 🥞 **[Layers Subsystem Architecture](Layers/ARCHITECTURE.md)** — Modular execution stack (`LayerStack`), regular game layers vs top-priority GUI overlays, deferred removals/additions, and event propagation pipelines.
 
-* ⏱️ **[Core Time Architecture](file:///e:/TimeEngine/Engine/src/Core/Time/ARCHITECTURE.md)** — Frame delta calculation, fixed-rate metronome tickers (`Ticker`), and static delayed/looping timers (`Timer::Set`, `Timer::NextFrame`).
-* 📁 **[Project Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Core/Project/ARCHITECTURE.md)** — Active workspace configuration (`ProjectConfig`), root directory resolution, and `.teproj` text file serialization (`ProjectSerializer`).
-* 📄 **[Core Public Headers & Threading Index](file:///e:/TimeEngine/Engine/Include/Core/ARCHITECTURE.md)** — Public header interface index (`Engine/Include/Core/`).
-* ⚙️ **[Engine Settings Architecture](file:///e:/TimeEngine/Engine/Include/Core/EngineSettings_ARCHITECTURE.md)** — Singleton engine configuration (`EngineSettings`), target framerates, VSync, logging filters, and `EngineSettingsLayer`.
-* 🔌 **[Plugin Manager Architecture](file:///e:/TimeEngine/Engine/src/Core/Plugin/ARCHITECTURE.md)** — Dynamic OS library loader (`LoadLibraryW` / `dlopen`), `.teplugin` descriptor parser, symbol factory lookups (`CreatePluginInstance`), and reverse-order unloader.
-
-
-
-
+* ⏱️ **[Core Time Architecture](Time/ARCHITECTURE.md)** — Frame delta calculation, fixed-rate metronome tickers (`Ticker`), and static delayed/looping timers (`Timer::Set`, `Timer::NextFrame`).
+* 📁 **[Project Subsystem Architecture](Project/ARCHITECTURE.md)** — Active workspace configuration (`ProjectConfig`), root directory resolution, and `.teproj` text file serialization (`ProjectSerializer`).
+* 📄 **[Core Public Headers & Threading Index](../../Include/Core/ARCHITECTURE.md)** — Public header interface index (`Engine/Include/Core/`).
+* ⚙️ **[Engine Settings Architecture](../../Include/Core/EngineSettings_ARCHITECTURE.md)** — Singleton engine configuration (`EngineSettings`), target framerates, VSync, logging filters, and `EngineSettingsLayer`.
+* 🔌 **[Plugin Manager Architecture](Plugin/ARCHITECTURE.md)** — Dynamic OS library loader (`LoadLibraryW` / `dlopen`), `.teplugin` descriptor parser, symbol factory lookups (`CreatePluginInstance`), and reverse-order unloader.
 
 ---
 
@@ -128,6 +124,23 @@ void Application::Run() {
 #### `Application::MarkLayerForAddition(layer)` & `Application::MarkLayerForRemoval(layer)`
 - **Why Deferred**: If a layer (or button event inside a layer) requests creating or destroying another layer during frame updates, modifying `m_LayerStack` directly would invalidate standard vector iterators and crash the engine loop.
 - **Mechanism**: `MarkLayerForAddition` queues layers into `m_LayersToAdd`, and `ProcessDeferredAdditions()` flushes them at the end of the frame step after `OnTimeGUIRender()` completes.
+
+---
+
+## Client Entry Point Architecture (`EntryPoint.h`)
+
+TimeEngine applications do not define a traditional `main()` function in user code. Instead, `EntryPoint.h` implements standard cross-platform entry points and delegates creation to the client via `TE::CreateApplication()`:
+
+```cpp
+// Executable entry point defined in Engine/src/Core/EntryPoint.h
+int main(int argc, char** argv) {
+    auto app = TE::CreateApplication(argc, argv);
+    app->Run();
+    delete app;
+    return 0;
+}
+```
+p after `OnTimeGUIRender()` completes.
 
 ---
 

--- a/Engine/src/Editor/ARCHITECTURE.md
+++ b/Engine/src/Editor/ARCHITECTURE.md
@@ -23,17 +23,18 @@ The Editor subsystem in TimeEngine powers the visual development workspace, mana
 
 ### Core Subsystems
 
-1. **Workspace Modes ([`EditorMode`](file:///e:/TimeEngine/Engine/Include/Editor/EditorMode.hpp))**:
+1. **Workspace Modes (`EditorMode` — `Engine/Include/Editor/EditorMode.hpp`)**:
    - Manages active editing state, viewport drawing, and toolbar icons.
    - Global registration macro: `T_REGISTER_EDITOR_MODE(MyModeClass)`.
 
-2. **Asset Inspection & Editing ([`AssetEditor`](file:///e:/TimeEngine/Engine/Include/Editor/AssetEditor.hpp) & [`AssetEditorRegistry`](file:///e:/TimeEngine/Engine/Include/Editor/AssetEditorRegistry.hpp))**:
+2. **Asset Inspection & Editing (`AssetEditor` & `AssetEditorRegistry` — `Engine/Include/Editor/AssetEditorRegistry.hpp`)**:
    - Handles specialized editor tabs opened inside the editor (`EditorTab`).
    - Maps file asset types (`.png`, `.tesprite`, `.temat`) to specialized editor drawers.
    - Global registration macro: `TE_REGISTER_ASSET_EDITOR(MyAssetEditor)`.
 
-3. **Editor Toolbar ([`EditorToolbar`](file:///e:/TimeEngine/Engine/Include/Editor/EditorToolbar.hpp))**:
+3. **Editor Toolbar (`EditorToolbar` — `Engine/Include/Editor/EditorToolbar.hpp`)**:
    - Renders top workspace controls, play/pause state toggles, and mode buttons using `TimeGUI`.
+
 
 ---
 

--- a/Engine/src/Input/ARCHITECTURE.md
+++ b/Engine/src/Input/ARCHITECTURE.md
@@ -26,16 +26,16 @@ The Input subsystem in TimeEngine handles raw device polling (keyboard, mouse), 
 
 ## Subsystem Components
 
-1. **Low-Level Device Polling ([`Input`](file:///e:/TimeEngine/Engine/Include/Input/Input.hpp))**:
+1. **Low-Level Device Polling (`Input` — `Engine/Include/Input/Input.hpp`)**:
    - Static class maintaining hardware states (`s_KeyStates`, `s_MouseStates`, scroll deltas).
    - Serves immediate polling queries from anywhere in the codebase.
 
 2. **High-Level Action Mapping System**:
-   - **[`InputAction`](file:///e:/TimeEngine/Engine/Include/Input/InputAction.hpp)**: Represents abstract actions (`Jump`, `Fire`, `Move2D`) with value types (`Digital` (bool), `Axis1D` (float), `Axis2D` (`TEVector2`)).
-   - **[`InputMappingContext`](file:///e:/TimeEngine/Engine/Include/Input/InputMappingContext.hpp)**: Map of keys to `InputAction` objects for specific gameplay states (e.g. `InGameContext`, `VehicleContext`).
-   - **[`InputRemapper`](file:///e:/TimeEngine/Engine/Include/Input/InputRemapper.hpp)**: Handles runtime key-rebinding overrides.
-   - **[`InputSystem`](file:///e:/TimeEngine/Engine/Include/Input/InputSystem.hpp)**: Singleton manager processing priority-sorted contexts each frame and executing bindings.
-   - **[`InputComponent`](file:///e:/TimeEngine/Engine/Include/Input/InputComponent.hpp)**: ECS component attached to game entities to register callback functions (`BindAction`).
+   - **`InputAction` (`Engine/Include/Input/InputAction.hpp`)**: Represents abstract actions (`Jump`, `Fire`, `Move2D`) with value types (`Digital` (bool), `Axis1D` (float), `Axis2D` (`TEVector2`)).
+   - **`InputMappingContext` (`Engine/Include/Input/InputMappingContext.hpp`)**: Map of keys to `InputAction` objects for specific gameplay states (e.g. `InGameContext`, `VehicleContext`).
+   - **`InputRemapper` (`Engine/Include/Input/InputRemapper.hpp`)**: Handles runtime key-rebinding overrides.
+   - **`InputSystem` (`Engine/Include/Input/InputSystem.hpp`)**: Singleton manager processing priority-sorted contexts each frame and executing bindings.
+   - **`InputComponent` (`Engine/Include/Input/InputComponent.hpp`)**: ECS component attached to game entities to register callback functions (`BindAction`).
 
 ---
 
@@ -95,7 +95,8 @@ inputComp->BindAction(jumpAction, [](const TE::InputActionValue& val) {
 
 ## Related Architectural Documentation
 
-- [Window Architecture](file:///e:/TimeEngine/Engine/src/Window/ARCHITECTURE.md) — OS window creation, GLFW callbacks, and input event hooks.
-- [Scene & ECS Architecture](file:///e:/TimeEngine/Engine/src/Core/Scene/ARCHITECTURE.md) — Entity-Component-System (ECS) architecture for attaching `InputComponent` to entities.
-- [Layers Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Core/Layers/ARCHITECTURE.md) — Top-to-bottom event propagation and input consumption.
+- [Window Architecture](../Window/ARCHITECTURE.md) — OS window creation, GLFW callbacks, and input event hooks.
+- [Scene & ECS Architecture](../Core/Scene/ARCHITECTURE.md) — Entity-Component-System (ECS) architecture for attaching `InputComponent` to entities.
+- [Layers Subsystem Architecture](../Core/Layers/ARCHITECTURE.md) — Top-to-bottom event propagation and input consumption.
+
 

--- a/Engine/src/Renderer/ARCHITECTURE.md
+++ b/Engine/src/Renderer/ARCHITECTURE.md
@@ -61,14 +61,15 @@ m_Renderer2D->EndFrame();
 
 ## Related Architectural Documentation
 
-- [OpenGL Graphics Backend Architecture](file:///e:/TimeEngine/Engine/src/Renderer/OpenGL/ARCHITECTURE.md) — Cross-platform OpenGL hardware backend implementation.
-- [OpenGL ES Graphics Backend Architecture](file:///e:/TimeEngine/Engine/src/Renderer/OpenGLES/ARCHITECTURE.md) — Embedded & mobile OpenGL ES hardware backend.
-- [DirectX 11 Graphics Backend Architecture](file:///e:/TimeEngine/Engine/src/Renderer/DirectX11/ARCHITECTURE.md) — Direct3D 11 hardware backend implementation.
-- [Vulkan Graphics Backend Architecture](file:///e:/TimeEngine/Engine/src/Renderer/Vulkan/ARCHITECTURE.md) — Explicit Vulkan 1.3 low-overhead hardware backend.
-- [Material Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Renderer/Material/ARCHITECTURE.md) — Node-based material pass stack and uniform caching.
-- [Camera Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Camera/ARCHITECTURE.md) — View and projection matrix math.
-- [Window Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Window/ARCHITECTURE.md) — OpenGL, DirectX & Vulkan graphics context creation.
-- [Utils & TimeGUI Architecture](file:///e:/TimeEngine/Engine/src/Utils/ARCHITECTURE.md) — Color utilities (`TEColor`) and UI rendering wrappers.
+- [OpenGL Graphics Backend Architecture](OpenGL/ARCHITECTURE.md) — Cross-platform OpenGL hardware backend implementation.
+- [OpenGL ES Graphics Backend Architecture](OpenGLES/ARCHITECTURE.md) — Embedded & mobile OpenGL ES hardware backend.
+- [DirectX 11 Graphics Backend Architecture](DirectX11/ARCHITECTURE.md) — Direct3D 11 hardware backend implementation.
+- [Vulkan Graphics Backend Architecture](Vulkan/ARCHITECTURE.md) — Explicit Vulkan 1.3 low-overhead hardware backend.
+- [Material Subsystem Architecture](Material/ARCHITECTURE.md) — Node-based material pass stack and uniform caching.
+- [Camera Subsystem Architecture](../Camera/ARCHITECTURE.md) — View and projection matrix math.
+- [Window Subsystem Architecture](../Window/ARCHITECTURE.md) — OpenGL, DirectX & Vulkan graphics context creation.
+- [Utils & TimeGUI Architecture](../Utils/ARCHITECTURE.md) — Color utilities (`TEColor`) and UI rendering wrappers.
+
 
 
 

--- a/Engine/src/Renderer/DirectX11/ARCHITECTURE.md
+++ b/Engine/src/Renderer/DirectX11/ARCHITECTURE.md
@@ -100,6 +100,7 @@ dx11API->InitWithWindow(nativeHwnd, 1920, 1080);
 
 ## Related Architectural Documentation
 
-- [Renderer Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Renderer/ARCHITECTURE.md) — Multi-backend 2D batching pipeline.
-- [Window Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Window/ARCHITECTURE.md) — Win32 `HWND` creation and event dispatch.
-- [Windows Platform Utilities Architecture](file:///e:/TimeEngine/Engine/src/Utils/Platform/Windows/ARCHITECTURE.md) — Win32 system dialogs and COM initialization.
+- [Renderer Subsystem Architecture](../ARCHITECTURE.md) — Multi-backend 2D batching pipeline.
+- [Window Subsystem Architecture](../../Window/ARCHITECTURE.md) — Win32 `HWND` creation and event dispatch.
+- [Windows Platform Utilities Architecture](../../Utils/Platform/Windows/ARCHITECTURE.md) — Win32 system dialogs and COM initialization.
+

--- a/Engine/src/Renderer/Material/ARCHITECTURE.md
+++ b/Engine/src/Renderer/Material/ARCHITECTURE.md
@@ -109,6 +109,7 @@ instance->ApplyUniforms();
 
 ## Related Architectural Documentation
 
-- [Renderer Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Renderer/ARCHITECTURE.md) — View-projection matrix binding in batch rendering.
-- [Editor & Asset Editors Architecture](file:///e:/TimeEngine/Engine/src/Editor/ARCHITECTURE.md) — Documentation for `MaterialAssetEditor` tab.
-- [Asset Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Core/Asset/ARCHITECTURE.md) — Asset handle and `.tematerial` path registration.
+- [Renderer Subsystem Architecture](../ARCHITECTURE.md) — View-projection matrix binding in batch rendering.
+- [Editor & Asset Editors Architecture](../../Editor/ARCHITECTURE.md) — Documentation for `MaterialAssetEditor` tab.
+- [Asset Subsystem Architecture](../../Core/Asset/ARCHITECTURE.md) — Asset handle and `.tematerial` path registration.
+

--- a/Engine/src/Renderer/OpenGL/ARCHITECTURE.md
+++ b/Engine/src/Renderer/OpenGL/ARCHITECTURE.md
@@ -96,6 +96,7 @@ RenderCommand::LoadLoader((void *(*)(const char *))m_Window->GetGLLoaderFunction
 
 ## Related Architectural Documentation
 
-- [Renderer Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Renderer/ARCHITECTURE.md) — Multi-backend 2D batching architecture.
-- [DirectX 11 Graphics Backend Architecture](file:///e:/TimeEngine/Engine/src/Renderer/DirectX11/ARCHITECTURE.md) — Direct3D 11 hardware backend implementation.
-- [Window Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Window/ARCHITECTURE.md) — GLFW window creation and OpenGL context initialization.
+- [Renderer Subsystem Architecture](../ARCHITECTURE.md) — Multi-backend 2D batching architecture.
+- [DirectX 11 Graphics Backend Architecture](../DirectX11/ARCHITECTURE.md) — Direct3D 11 hardware backend implementation.
+- [Window Subsystem Architecture](../../Window/ARCHITECTURE.md) — GLFW window creation and OpenGL context initialization.
+

--- a/Engine/src/Renderer/OpenGLES/ARCHITECTURE.md
+++ b/Engine/src/Renderer/OpenGLES/ARCHITECTURE.md
@@ -20,5 +20,6 @@ The OpenGL ES (GLES) graphics backend in TimeEngine provides embedded and mobile
 
 ## Related Architectural Documentation
 
-- [Renderer Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Renderer/ARCHITECTURE.md) — Multi-backend 2D batching pipeline.
-- [OpenGL Graphics Backend Architecture](file:///e:/TimeEngine/Engine/src/Renderer/OpenGL/ARCHITECTURE.md) — Desktop OpenGL backend implementation.
+- [Renderer Subsystem Architecture](../ARCHITECTURE.md) — Multi-backend 2D batching pipeline.
+- [OpenGL Graphics Backend Architecture](../OpenGL/ARCHITECTURE.md) — Desktop OpenGL backend implementation.
+

--- a/Engine/src/Renderer/Vulkan/ARCHITECTURE.md
+++ b/Engine/src/Renderer/Vulkan/ARCHITECTURE.md
@@ -22,5 +22,6 @@ The Vulkan graphics backend in TimeEngine provides explicit low-level Vulkan 1.3
 
 ## Related Architectural Documentation
 
-- [Renderer Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Renderer/ARCHITECTURE.md) — Multi-backend 2D batching pipeline.
-- [DirectX 11 Graphics Backend Architecture](file:///e:/TimeEngine/Engine/src/Renderer/DirectX11/ARCHITECTURE.md) — Direct3D 11 hardware backend implementation.
+- [Renderer Subsystem Architecture](../ARCHITECTURE.md) — Multi-backend 2D batching pipeline.
+- [DirectX 11 Graphics Backend Architecture](../DirectX11/ARCHITECTURE.md) — Direct3D 11 hardware backend implementation.
+

--- a/Engine/src/Utils/ARCHITECTURE.md
+++ b/Engine/src/Utils/ARCHITECTURE.md
@@ -11,13 +11,14 @@ The `Utils` module in TimeEngine provides foundational, vendor-decoupled utility
 
 ## Platform Utilities Link Reference
 
-- [Platform Utilities Architecture](file:///e:/TimeEngine/Engine/src/Utils/Platform/ARCHITECTURE.md) — Architectural documentation for OS-specific platform utilities.
+- [Platform Utilities Architecture](Platform/ARCHITECTURE.md) — Architectural documentation for OS-specific platform utilities.
 
 ---
 
 ## 1. Math Utilities (`MathUtils`)
 
-[`TE::MathUtils`](file:///e:/TimeEngine/Engine/Include/Utils/MathUtils.hpp) defines engine math primitives, avoiding hard vendor dependencies in engine header files.
+`TE::MathUtils` (`Engine/Include/Utils/MathUtils.hpp`) defines engine math primitives, avoiding hard vendor dependencies in engine header files.
+
 
 ### Key Types & Conversion Overloads
 - **`TEVector2` / `TEVector` / `TEVector4`**: 2D, 3D, and 4D float vectors (with primary 2D focus for engine transforms, UI alignment, and sprite positioning) equipped with magnitude, normalization, dot/cross products, linear interpolation (`Lerp`), and seamless conversion to/from UI types (`ImVec2`, `ImVec4`).

--- a/Engine/src/Utils/Platform/ARCHITECTURE.md
+++ b/Engine/src/Utils/Platform/ARCHITECTURE.md
@@ -1,8 +1,9 @@
 # Platform Utilities Architecture
 
-The `Platform` module under `Utils/Platform/` contains platform-specific implementations of the [`TE::PlatformUtils`](file:///e:/TimeEngine/Engine/Include/Utils/PlatformUtils.hpp) interface.
+The `Platform` module under `Utils/Platform/` contains platform-specific implementations of the `TE::PlatformUtils` (`Engine/Include/Utils/PlatformUtils.hpp`) interface.
 
 ## Platform Implementations
 
-- [Windows Platform Architecture](file:///e:/TimeEngine/Engine/src/Utils/Platform/Windows/ARCHITECTURE.md) — Windows OS implementation using COM shell dialogs (`IFileDialog`), `GetOpenFileNameA`, Windows Registry (`RegCreateKeyExA`), and `GetModuleFileNameA`.
-- [Unix Platform Architecture](file:///e:/TimeEngine/Engine/src/Utils/Platform/Unix/ARCHITECTURE.md) — POSIX / Linux implementation details.
+- [Windows Platform Architecture](Windows/ARCHITECTURE.md) — Windows OS implementation using COM shell dialogs (`IFileDialog`), `GetOpenFileNameA`, Windows Registry (`RegCreateKeyExA`), and `GetModuleFileNameA`.
+- [Unix Platform Architecture](Unix/ARCHITECTURE.md) — POSIX / Linux implementation details.
+

--- a/Engine/src/Window/ARCHITECTURE.md
+++ b/Engine/src/Window/ARCHITECTURE.md
@@ -10,9 +10,10 @@ The Window subsystem in TimeEngine provides platform-agnostic OS window creation
 
 ## Component Overview
 
-- **Interface**: [`IWindow`](file:///e:/TimeEngine/Engine/Include/Window/IWindow.hpp) — Pure virtual abstract base class defining window operations.
-- **Platform Implementation**: [`WindowsWindow`](file:///e:/TimeEngine/Engine/Include/Window/WindowsWindow.hpp) (`WindowsWindow.cpp`) — GLFW-backed desktop window implementation for Windows platforms.
+- **Interface**: `IWindow` (`Engine/Include/Window/IWindow.hpp`) — Pure virtual abstract base class defining window operations.
+- **Platform Implementation**: `WindowsWindow` (`Engine/Include/Window/WindowsWindow.hpp`) (`WindowsWindow.cpp`) — GLFW-backed desktop window implementation for Windows platforms.
 - **Properties Struct**: `WindowProps` — Holds initial title, width, and height configuration.
+
 
 ## Architecture & Responsibilities
 

--- a/TimeEditor/ARCHITECTURE.md
+++ b/TimeEditor/ARCHITECTURE.md
@@ -10,9 +10,10 @@ The `TimeEditor` directory contains the Integrated Game Development Environment 
 ## 📂 Subsystem Breakdown & Architecture Links
 
 * 🚀 **[Editor Application Entry & Lifecycle](src/ARCHITECTURE.md)** (`TimeEditor/src/`) — Client entry point (`TimeEditorApplication.cpp`), high-performance discrete GPU exports, `.teproj` Win32 file extension registration, and `LogoLayer` $\rightarrow$ `ProjectHubLayer` $\rightarrow$ `EditorLayer` startup sequence.
-* 🛠️ **[Engine Editor Subsystem](file:///e:/TimeEngine/Engine/src/Editor/ARCHITECTURE.md)** — Workspace modes (`EditorModeRegistry`), modal asset drawers (`AssetEditorRegistry`), and toolbar controls (`EditorToolbar`).
-* 🥞 **[Layers Architecture](file:///e:/TimeEngine/Engine/src/Core/Layers/ARCHITECTURE.md)** — `ProjectHubLayer` launcher, `EditorLayer` workspace, `ProfilingLayer`, `EngineSettingsLayer`, and `TimeGUILayer`.
-* 🏠 **[Root Architecture Index](file:///e:/TimeEngine/ARCHITECTURE.md)** — Master TimeEngine architecture index.
+* 🛠️ **[Engine Editor Subsystem](../Engine/src/Editor/ARCHITECTURE.md)** — Workspace modes (`EditorModeRegistry`), modal asset drawers (`AssetEditorRegistry`), and toolbar controls (`EditorToolbar`).
+* 🥞 **[Layers Architecture](../Engine/src/Core/Layers/ARCHITECTURE.md)** — `ProjectHubLayer` launcher, `EditorLayer` workspace, `ProfilingLayer`, `EngineSettingsLayer`, and `TimeGUILayer`.
+* 🏠 **[Root Architecture Index](../ARCHITECTURE.md)** — Master TimeEngine architecture index.
+
 
 ---
 

--- a/TimeEditor/src/ARCHITECTURE.md
+++ b/TimeEditor/src/ARCHITECTURE.md
@@ -71,7 +71,8 @@ Before loading the editor workspace, `TimeEditorApplication.cpp` checks `<Projec
 
 ## Related Architectural Documentation
 
-- [TimeEditor Architecture](file:///e:/TimeEngine/TimeEditor/ARCHITECTURE.md) — Top-level TimeEditor suite overview.
-- [Editor Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Editor/ARCHITECTURE.md) — Workspace modes, asset tabs, and toolbars.
-- [Layers Subsystem Architecture](file:///e:/TimeEngine/Engine/src/Core/Layers/ARCHITECTURE.md) — `LogoLayer`, `ProjectHubLayer`, and `EditorLayer`.
-- [Root Architecture Index](file:///e:/TimeEngine/ARCHITECTURE.md) — Master TimeEngine architecture hub.
+- [TimeEditor Architecture](../ARCHITECTURE.md) — Top-level TimeEditor suite overview.
+- [Editor Subsystem Architecture](../../Engine/src/Editor/ARCHITECTURE.md) — Workspace modes, asset tabs, and toolbars.
+- [Layers Subsystem Architecture](../../Engine/src/Core/Layers/ARCHITECTURE.md) — `LogoLayer`, `ProjectHubLayer`, and `EditorLayer`.
+- [Root Architecture Index](../../ARCHITECTURE.md) — Master TimeEngine architecture hub.
+


### PR DESCRIPTION
## Description
This PR performs a comprehensive sweep of all architectural documentation files across the codebase to finalize relative links. It converts absolute file URIs (such as local `file:///` paths) into standard, GitHub-compatible relative repository links. This ensures that the navigation links in our design and architecture documents are fully functional when viewed directly on GitHub or other Git interfaces.

## Related Issues
- Resolves: Documentation link accessibility and navigation fixes.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Style / Refactoring

## How Has This Been Tested?
- Visually reviewed changed files to verify markdown links resolve correctly under the relative repository structure.
- Confirmed that no C++ source files or build configurations were affected by this changeset.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] **Determinism Check**: If adding logic, I have ensured it is deterministic and time-aware.